### PR TITLE
Production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work
 
 node_modules
 .parcel-cache
+
+main

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	app := app.App{
 		Groups: groups,
-		Stamp:  config.Stamp,
+		Stamp:  config.Hash,
 	}
 
 	for _, group := range groups {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
-go run cmd/client/main.go
+FILE=./main
+if [ ! -f "$FILE" ]; then
+    echo "Compiling..."
+    go build cmd/client/main.go
+fi
+
+./main
 npm run build
 npx wrangler pages publish build --commit-dirty=true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,12 +1,33 @@
 package config
 
 import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"log"
+	"os"
 	"strconv"
 	"time"
 )
 
-var Stamp string
+var (
+	Stamp string
+	Hash  string
+)
 
 func init() {
 	Stamp = strconv.FormatInt(time.Now().UnixMicro(), 16)
+
+	f, err := os.Open("./build/assets/css/app.css")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
+
+	Hash = fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/github/release.go
+++ b/pkg/github/release.go
@@ -21,6 +21,8 @@ type Release struct {
 	HTML      string
 	CardClass string
 
+	MajorVersion string
+
 	// Specifies the commitish value that determines where the Git tag is
 	// created from. Can be any branch or commit SHA. Unused if the Git tag
 	// already exists. Default: the repository’s default branch (usually master).

--- a/pkg/project/major.go
+++ b/pkg/project/major.go
@@ -1,0 +1,33 @@
+package project
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/levidurfee/rlsz_dev/pkg/github"
+	"github.com/levidurfee/rlsz_dev/pkg/version"
+)
+
+func (p *Project) getMajors() {
+	var majors []*github.Release
+	var mjrs []string
+
+	for _, release := range p.Releases {
+		version := strings.Split(release.TagName, ".")
+
+		if !contains(mjrs, version[0]) {
+			release.MajorVersion = version[0]
+			mjrs = append(mjrs, version[0])
+			majors = append(majors, release)
+		}
+	}
+
+	sort.Slice(majors, func(i, j int) bool {
+		vi := version.StripVersion(majors[i].TagName)
+		vj := version.StripVersion(majors[j].TagName)
+
+		return vi > vj
+	})
+
+	p.Majors = majors
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,9 +1,6 @@
 package project
 
 import (
-	"sort"
-	"strings"
-
 	"github.com/levidurfee/rlsz_dev/pkg/config"
 	"github.com/levidurfee/rlsz_dev/pkg/github"
 )
@@ -16,7 +13,7 @@ type Project struct {
 
 	Repository *github.Repository
 	Releases   []*github.Release
-	Majors     []string
+	Majors     []*github.Release
 
 	Index bool
 }
@@ -68,24 +65,6 @@ func (p *Project) getReleases() error {
 	p.Releases = releases
 
 	return nil
-}
-
-func (p *Project) getMajors() {
-	var majors []string
-
-	for _, release := range p.Releases {
-		version := strings.Split(release.TagName, ".")
-
-		if !contains(majors, version[0]) {
-			majors = append(majors, version[0])
-		}
-	}
-
-	sort.Slice(majors, func(i, j int) bool {
-		return majors[i] > majors[j]
-	})
-
-	p.Majors = majors
 }
 
 func contains(s []string, str string) bool {

--- a/pkg/project/write.go
+++ b/pkg/project/write.go
@@ -54,7 +54,7 @@ func (p Project) writeMajors() error {
 		for _, release := range releases {
 			// Check if release matches major
 			ver := strings.Split(release.TagName, ".")
-			if ver[0] != major {
+			if ver[0] != major.MajorVersion {
 				continue
 			}
 			// Add it to a temp releases slice
@@ -64,9 +64,9 @@ func (p Project) writeMajors() error {
 		// Set p.Releases to temp releases slice
 		tmpProject.Releases = temp
 		// Update name / title
-		tmpProject.Name = p.Name + " " + major
+		tmpProject.Name = p.Name + " " + major.MajorVersion
 		// Write file
-		write(tmpProject, filepath.Join("build", p.Path), major+".html")
+		write(tmpProject, filepath.Join("build", p.Path), major.MajorVersion+".html")
 	}
 
 	return nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var reg *regexp.Regexp
+
+func init() {
+	r, err := regexp.Compile(`[a-zA-Z\.-]`)
+	if err != nil {
+		panic(err)
+	}
+	reg = r
+}
+
+func StripVersion(i string) int {
+	version := strings.Split(i, ".")
+	i = reg.ReplaceAllString(version[0], "")
+
+	v, _ := strconv.Atoi(i)
+
+	return v
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestStripVersion(t *testing.T) {
+	versions := map[string]int{
+		"v9":  9,
+		"v1":  1,
+		"v13": 13,
+	}
+
+	for k, v := range versions {
+		version := StripVersion(k)
+
+		if version != v {
+			t.Error("Error")
+		}
+	}
+}

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -18,10 +18,13 @@
                             <div class="card-header">
                                 <h2 class="h5 mb-0"><a class="text-decoration-none" href="/{{ .Path }}">{{ .Name }}</a></h2>
                             </div>
-                            <div class="list-group list-group-flush">
+                            <div class="list-group list-group-flush d-flex">
                                 {{ $path := .Path }}
                                 {{ range .Majors }}
-                                    <a class="list-group-item list-group-item-action" href="/{{ $path }}/{{ . }}.html">{{ . }}</a>
+                                    <a class="list-group-item list-group-item-action d-flex justify-content-between" href="/{{ $path }}/{{ .MajorVersion }}.html">
+                                        <span>{{ .MajorVersion }}</span>
+                                        <span>{{ .PublishedAt }}</span>
+                                    </a>
                                 {{ end }}
                             </div>
                         </div>


### PR DESCRIPTION
- Use MD5 hash of CSS file for cache-busting query string
- Show the latest major version release dates on the index page
- Update the build script so it doesn't compile every deploy